### PR TITLE
Bugfix: Resolving custom clientOutput

### DIFF
--- a/src/file/source-path.ts
+++ b/src/file/source-path.ts
@@ -8,7 +8,12 @@ export function getSourcePath(
   if (overrideTarget) {
     // schema relative
     if (overrideTarget.startsWith('./')) {
-      return path.resolve(schemaTarget!, overrideTarget);
+      return path.resolve(
+        // schemaTarget is the full path of the Prisma schema - we need the directory
+        path.dirname(schemaTarget!),
+        overrideTarget,
+        overrideTarget.endsWith('.d.ts') ? '' : 'index.d.ts'
+      );
     }
 
     // importable


### PR DESCRIPTION
Context: Using a custom `output` on the client generator and providing a `clientOutput` parameter to the `prisma-json-types-generator` 
![image](https://user-images.githubusercontent.com/34269850/219494262-eb922077-dca8-4726-9fbe-0244a8579f4f.png)

It seems that the logic in the code to resolve it is wrong. It tries to resolve the output path based on the full schema path (including schema file name) so it ends up being something like `/some/path/schema.prisma/[clientOutput]`

Appending a `index.d.ts` to the end there (if it's needed) is not related to the bug, but I think it's nicer if the user can provided `clientOutput` that matches the `output` on the client generator