### PR TITLE
fix: support deeper relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist
-.vscode/settings.json	
+.vscode/settings.json
+.idea

--- a/src/file/source-path.ts
+++ b/src/file/source-path.ts
@@ -6,18 +6,18 @@ export function getSourcePath(
   schemaTarget?: string
 ) {
   if (overrideTarget) {
-    // schema relative
-    if (overrideTarget.startsWith('./')) {
-      return path.resolve(
-        // schemaTarget is the full path of the Prisma schema - we need the directory
-        path.dirname(schemaTarget!),
-        overrideTarget,
-        overrideTarget.endsWith('.d.ts') ? '' : 'index.d.ts'
-      );
+    if (path.isAbsolute(overrideTarget)) {
+      // importable
+      return require.resolve(overrideTarget);
     }
 
-    // importable
-    return require.resolve(overrideTarget);
+    // schema relative
+    return path.resolve(
+      // schemaTarget is the full path of the Prisma schema - we need the directory
+      path.dirname(schemaTarget!),
+      overrideTarget,
+      overrideTarget.endsWith('.d.ts') ? '' : 'index.d.ts'
+    );
   }
 
   return path.resolve(


### PR DESCRIPTION
Support `output` directories that are higher up. e.g. `"../../src/prisma/client"`