### PR TITLE
fix: find client generator by provider instead of the name

### DIFF
--- a/src/util/prisma-generator.ts
+++ b/src/util/prisma-generator.ts
@@ -6,7 +6,7 @@ import { PrismaJsonTypesGeneratorError } from './error';
  * an error.
  */
 export function findPrismaClientGenerator(generators: GeneratorConfig[]) {
-  const options = generators.find((g) => g.name === 'client');
+  const options = generators.find((g) => g.provider.value === 'prisma-client-js');
 
   if (!options) {
     throw new PrismaJsonTypesGeneratorError(


### PR DESCRIPTION
The `findPrismaClientGenerator` was searching the client generator by name, which can be an arbitrary value chosen by the developer

This PR changes to code to finds the generator by provider `prisma-client-js`.

If this is a very intrusive change, I believe it is worth highlighting in the documentation that the generator title must be equal to `client`.