### PR TITLE
fix: make nots optional

### DIFF
--- a/assets/namespace.d.ts
+++ b/assets/namespace.d.ts
@@ -42,7 +42,7 @@ export type TypedNestedStringFilter<S extends string> =
     equals?: S;
     in?: S[];
     notIn?: S[];
-    not: TypedNestedStringFilter<S> | S;
+    not?: TypedNestedStringFilter<S> | S;
   };
 
 /**
@@ -55,7 +55,7 @@ export type TypedStringFilter<S extends string> =
     equals?: S;
     in?: S[];
     notIn?: S[];
-    not: TypedNestedStringFilter<S> | S;
+    not?: TypedNestedStringFilter<S> | S;
   };
 
 /**
@@ -68,7 +68,7 @@ export type TypedNestedStringNullableFilter<S extends string> =
     equals?: S | null;
     in?: S[] | null;
     notIn?: S[] | null;
-    not: TypedNestedStringNullableFilter<S> | S | null;
+    not?: TypedNestedStringNullableFilter<S> | S | null;
   };
 
 /**
@@ -81,7 +81,7 @@ export type TypedStringNullableFilter<S extends string> =
     equals?: S | null;
     in?: S[] | null;
     notIn?: S[] | null;
-    not: TypedNestedStringNullableFilter<S> | S | null;
+    not?: TypedNestedStringNullableFilter<S> | S | null;
   };
 
 /**
@@ -94,7 +94,7 @@ export type TypedNestedStringWithAggregatesFilter<S extends string> =
     equals?: S;
     in?: S[];
     notIn?: S[];
-    not: TypedNestedStringWithAggregatesFilter<S> | S;
+    not?: TypedNestedStringWithAggregatesFilter<S> | S;
   };
 
 /**
@@ -120,7 +120,7 @@ export type TypedNestedStringNullableWithAggregatesFilter<S extends string> =
     equals?: S | null;
     in?: S[] | null;
     notIn?: S[] | null;
-    not: TypedNestedStringNullableWithAggregatesFilter<S> | S | null;
+    not?: TypedNestedStringNullableWithAggregatesFilter<S> | S | null;
   };
 
 /**

--- a/test/types/cockroach.test-d.ts
+++ b/test/types/cockroach.test-d.ts
@@ -71,3 +71,12 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
+
+expectType<Text>({
+  id: 0,
+  untyped: '' as string,
+  typed: {
+    in: ['C'] as PCockroachJson.WithType[]
+  },
+  literal: 'A' as 'A' | 'B'
+});

--- a/test/types/mongo.test-d.ts
+++ b/test/types/mongo.test-d.ts
@@ -127,3 +127,12 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
+
+expectType<Text>({
+  id: '0',
+  untyped: '' as string,
+  typed: {
+    in: ['C'] as PMongoJson.WithType[]
+  },
+  literal: 'A' as 'A' | 'B'
+});

--- a/test/types/mssql.test-d.ts
+++ b/test/types/mssql.test-d.ts
@@ -20,3 +20,12 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
+
+expectType<Text>({
+  id: 0,
+  untyped: '' as string,
+  typed: {
+    in: ['C'] as PMssqlJson.WithType[]
+  },
+  literal: 'A' as 'A' | 'B'
+});

--- a/test/types/mysql.test-d.ts
+++ b/test/types/mysql.test-d.ts
@@ -71,3 +71,12 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
+
+expectType<Text>({
+  id: 0,
+  untyped: '' as string,
+  typed: {
+    in: ['C'] as PMysqlJson.WithType[]
+  },
+  literal: 'A' as 'A' | 'B'
+});

--- a/test/types/sqlite.test-d.ts
+++ b/test/types/sqlite.test-d.ts
@@ -20,3 +20,12 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
+
+expectType<Text>({
+  id: 0,
+  untyped: '' as string,
+  typed: {
+    in: ['C'] as PSqliteJson.WithType[]
+  },
+  literal: 'A' as 'A' | 'B'
+});

--- a/test/types/string.test-d.ts
+++ b/test/types/string.test-d.ts
@@ -20,3 +20,12 @@ expectNotType<Model>({
   typed: 'D' as string,
   literal: 'D' as string
 });
+
+expectType<Model>({
+  id: 0,
+  untyped: '' as string,
+  typed: {
+    in: ['C'] as PStringJson.WithType[]
+  },
+  literal: 'A' as 'A' | 'B'
+});


### PR DESCRIPTION
Upon using this generator I've ran into an issue where the `not` condition was mandatory for some of the typed filters.

I think this was a mistake, so I've pushed a PR where this is no longer the case, alongside some tests.

Before this fix when making a `WHERE IN`, we'd be forced to make a `WHERE NOT` as well by ts. 

Example before fix:
```ts
    prismaClient.someModel.findFirst({
      where: {
        someColumn: {
          in: [ ...listOfValues ],
          not: 'I have to include a not condition too otherwise ts complains :( how sad'
        },
      },
    });
```

Now
```ts
    prismaClient.someModel.findFirst({
      where: {
        someColumn: {
          in: [ ...listOfValues ],
        },
      },
    });
```

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
