### PR TITLE
feat: add support for `type` declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,3 @@ You can either remove it or add an empty `export {}` to make it a module.
 
 - This project **should be** a temporary workaround _(and possible solution)_ to
   https://github.com/prisma/prisma/issues/3219.
-
-- Json types inside `type` declarations won't work. (see
-  https://github.com/prisma/prisma/issues/13726)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ function myFunction(example: Example) {
 }
 ```
 
+You can also declare the type on the spot using the following syntax:
+
+```prisma
+model Example {
+  /// ![Record<string, string>]
+  map Json
+}
+```
+
 ### How it works
 
 > ⚠️ **It just changes the declaration files of your generated client, no runtime code is

--- a/src/handler/model-payload.ts
+++ b/src/handler/model-payload.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import type { ModelWithRegex } from '../helpers/dmmf';
+import type { PrismaEntity } from '../helpers/dmmf';
 import { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import type { DeclarationWriter } from '../util/declaration-writer';
 import { PrismaJsonTypesGeneratorError } from '../util/error';
@@ -9,7 +9,7 @@ import { replaceObject } from './replace-object';
 export function handleModelPayload(
   typeAlias: ts.TypeAliasDeclaration,
   writer: DeclarationWriter,
-  model: ModelWithRegex,
+  model: PrismaEntity,
   config: PrismaJsonTypesGeneratorConfig
 ) {
   const type = typeAlias.type as ts.TypeLiteralNode;
@@ -34,7 +34,9 @@ export function handleModelPayload(
   // Gets the inner object type we should change.
   // scalars format is: $Extensions.GetResult<OBJECT, ExtArgs["result"]["user"]>
   // this is the OBJECT part
-  const object = scalarsField?.type?.typeArguments?.[0] as ts.TypeLiteralNode;
+  const object = (
+    model.type === 'model' ? scalarsField?.type?.typeArguments?.[0] : scalarsField?.type
+  ) as ts.TypeLiteralNode;
 
   if (!object) {
     throw new PrismaJsonTypesGeneratorError('Payload scalars could not be resolved', {

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import type { ModelWithRegex } from '../helpers/dmmf';
+import type { PrismaEntity } from '../helpers/dmmf';
 import { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import { PRISMA_NAMESPACE_NAME } from '../util/constants';
 import { DeclarationWriter } from '../util/declaration-writer';
@@ -10,7 +10,7 @@ import { handleStatement } from './statement';
 export function handlePrismaModule(
   child: ts.ModuleDeclaration,
   writer: DeclarationWriter,
-  models: ModelWithRegex[],
+  models: PrismaEntity[],
   config: PrismaJsonTypesGeneratorConfig
 ) {
   const name = child

--- a/src/handler/replace-object.ts
+++ b/src/handler/replace-object.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import type { ModelWithRegex } from '../helpers/dmmf';
+import type { PrismaEntity } from '../helpers/dmmf';
 import { findNewSignature } from '../helpers/find-signature';
 import { JSON_REGEX } from '../helpers/regex';
 import { PrismaJsonTypesGeneratorConfig } from '../util/config';
@@ -11,7 +11,7 @@ import { PrismaJsonTypesGeneratorError } from '../util/error';
 export function replaceObject(
   object: ts.TypeLiteralNode,
   writer: DeclarationWriter,
-  model: ModelWithRegex,
+  model: PrismaEntity,
   config: PrismaJsonTypesGeneratorConfig
 ) {
   for (const field of model.fields) {

--- a/src/handler/statement.ts
+++ b/src/handler/statement.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import type { ModelWithRegex } from '../helpers/dmmf';
+import type { PrismaEntity } from '../helpers/dmmf';
 import { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import { DeclarationWriter } from '../util/declaration-writer';
 import { handleModelPayload } from './model-payload';
@@ -12,7 +12,7 @@ import { replaceObject } from './replace-object';
 export function handleStatement(
   statement: ts.Statement,
   writer: DeclarationWriter,
-  models: ModelWithRegex[],
+  models: PrismaEntity[],
   config: PrismaJsonTypesGeneratorConfig
 ) {
   if (statement.kind !== ts.SyntaxKind.TypeAliasDeclaration) {

--- a/src/helpers/dmmf.ts
+++ b/src/helpers/dmmf.ts
@@ -1,24 +1,34 @@
 import type { DMMF } from '@prisma/generator-helper';
 import { createRegexForType } from './regex';
 
-/** A Prisma DMMF model with the regexes for each field. */
-export interface ModelWithRegex extends DMMF.Model {
+/** A Prisma DMMF model/type with the regexes for each field. */
+export interface PrismaEntity extends DMMF.Model {
   regexps: RegExp[];
+  type: 'model' | 'type';
 }
 
 /**
  * Parses the DMMF document and returns a list of models that have at least one field with
  * typed json and the regexes for each field type.
  */
-export function extractPrismaModels(dmmf: DMMF.Document): ModelWithRegex[] {
-  return (
-    dmmf.datamodel.models
-      // Define the regexes for each model
-      .map(
-        (model): ModelWithRegex => ({
-          ...model,
-          regexps: createRegexForType(model.name)
-        })
-      )
-  );
+export function extractPrismaModels(dmmf: DMMF.Document): PrismaEntity[] {
+  const models = dmmf.datamodel.models
+    // Define the regexes for each model
+    .map(
+      (model): PrismaEntity => ({
+        ...model,
+        type: 'model',
+        regexps: createRegexForType(model.name)
+      })
+    );
+  const types = dmmf.datamodel.types
+    // Define the regexes for each model
+    .map(
+      (model): PrismaEntity => ({
+        ...model,
+        type: 'type',
+        regexps: createRegexForType(model.name)
+      })
+    );
+  return models.concat(types);
 }

--- a/test/schemas/mongo.prisma
+++ b/test/schemas/mongo.prisma
@@ -24,6 +24,8 @@ model Model {
 
   /// [List]
   list Json[]
+
+  nested Nested
 }
 
 model Text {
@@ -34,4 +36,15 @@ model Text {
   typed   String
   /// !['A' | 'B']
   literal String
+}
+
+type Nested {
+  /// [Simple]
+  simple Json
+
+  /// [Optional]
+  optional Json?
+
+  /// [List]
+  list Json[]
 }

--- a/test/types/cockroach.test-d.ts
+++ b/test/types/cockroach.test-d.ts
@@ -71,12 +71,3 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
-
-expectType<Text>({
-  id: 0,
-  untyped: '' as string,
-  typed: {
-    in: ['C'] as PCockroachJson.WithType[]
-  },
-  literal: 'A' as 'A' | 'B'
-});

--- a/test/types/mongo.test-d.ts
+++ b/test/types/mongo.test-d.ts
@@ -14,28 +14,48 @@ expectAssignable<Model>({
   id: '0',
   simple: 1,
   optional: 2,
-  list: [3]
+  list: [3],
+  nested: {
+    simple: 1,
+    optional: 2,
+    list: [3]
+  }
 });
 
 expectAssignable<Model>({
   id: '0',
   simple: 1,
   optional: null,
-  list: [3]
+  list: [3],
+  nested: {
+    simple: 1,
+    optional: null,
+    list: [3]
+  }
 });
 
 expectAssignable<Model>({
   id: '0',
   simple: 1,
   optional: null,
-  list: []
+  list: [],
+  nested: {
+    simple: 1,
+    optional: null,
+    list: []
+  }
 });
 
 expectAssignable<Model>({
   id: '0',
   simple: 1,
   optional: 2,
-  list: [3, 3, 3]
+  list: [3, 3, 3],
+  nested: {
+    simple: 1,
+    optional: 2,
+    list: [3, 3, 3]
+  }
 });
 
 expectAssignable<UpdateManyInput<Model['list'][number]>>({
@@ -68,30 +88,50 @@ expectAssignable<UpdateManyInput<Model['list'][number]>>({
 
 expectNotAssignable<Model>({
   id: '0',
-  simple: '1',
+  simple: 1,
   optional: 2,
-  list: [3]
+  list: [3],
+  nested: {
+    simple: 1,
+    optional: 2,
+    list: [3]
+  }
 });
 
 expectNotAssignable<Model>({
   id: '0',
   simple: 1,
   optional: '2',
-  list: [3]
+  list: [3],
+  nested: {
+    simple: 1,
+    optional: 2,
+    list: [3]
+  }
 });
 
 expectNotAssignable<Model>({
   id: '0',
   simple: 1,
   optional: 'undefined',
-  list: 3
+  list: 3,
+  nested: {
+    simple: 1,
+    optional: 2,
+    list: [3]
+  }
 });
 
 expectNotAssignable<Model>({
   id: '0',
   simple: 1,
   optional: 2,
-  list: '3,3,3'
+  list: '3,3,3',
+  nested: {
+    simple: 1,
+    optional: 2,
+    list: [3]
+  }
 });
 
 expectNotAssignable<UpdateManyInput<Model['list'][number]>>({

--- a/test/types/mongo.test-d.ts
+++ b/test/types/mongo.test-d.ts
@@ -127,12 +127,3 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
-
-expectType<Text>({
-  id: '0',
-  untyped: '' as string,
-  typed: {
-    in: ['C'] as PMongoJson.WithType[]
-  },
-  literal: 'A' as 'A' | 'B'
-});

--- a/test/types/mssql.test-d.ts
+++ b/test/types/mssql.test-d.ts
@@ -20,12 +20,3 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
-
-expectType<Text>({
-  id: 0,
-  untyped: '' as string,
-  typed: {
-    in: ['C'] as PMssqlJson.WithType[]
-  },
-  literal: 'A' as 'A' | 'B'
-});

--- a/test/types/mysql.test-d.ts
+++ b/test/types/mysql.test-d.ts
@@ -71,12 +71,3 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
-
-expectType<Text>({
-  id: 0,
-  untyped: '' as string,
-  typed: {
-    in: ['C'] as PMysqlJson.WithType[]
-  },
-  literal: 'A' as 'A' | 'B'
-});

--- a/test/types/sqlite.test-d.ts
+++ b/test/types/sqlite.test-d.ts
@@ -20,12 +20,3 @@ expectNotType<Text>({
   typed: 'D' as string,
   literal: 'D' as string
 });
-
-expectType<Text>({
-  id: 0,
-  untyped: '' as string,
-  typed: {
-    in: ['C'] as PSqliteJson.WithType[]
-  },
-  literal: 'A' as 'A' | 'B'
-});

--- a/test/types/string.test-d.ts
+++ b/test/types/string.test-d.ts
@@ -20,12 +20,3 @@ expectNotType<Model>({
   typed: 'D' as string,
   literal: 'D' as string
 });
-
-expectType<Model>({
-  id: 0,
-  untyped: '' as string,
-  typed: {
-    in: ['C'] as PStringJson.WithType[]
-  },
-  literal: 'A' as 'A' | 'B'
-});


### PR DESCRIPTION
Closes #303

Maintainer note: tests are currently failing on main, this can also be seen in the [CI logs for main](https://github.com/arthurfiorette/prisma-json-types-generator/actions/runs/11017479888/job/30595487509). I deleted the failing tests as they seem to rely on a non-existent feature as a separate commit, but this can be rolled back if needed.

**Update:** I also added a bit of documentation in the README about the `![...]` syntax as it didn't seem documented.