### PR TITLE
fix issue and  add multimodel prisma schema and tests

### DIFF
--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -35,14 +35,13 @@ export function handlePrismaModule(
     try {
       handleStatement(statement, writer, models, config);
     } catch (error) {
-      // This allows some types to be generated even if others may fail
-      // which is good for incremental development/testing
       if (error instanceof PrismaJsonTypesGeneratorError) {
-        return PrismaJsonTypesGeneratorError.handler(error);
+        console.error('PrismaJsonTypesGeneratorError:', error);
+      } else {
+        console.error('Unexpected error:', error);
       }
-
-      // Stops this generator is error thrown is not manually added by our code.
-      throw error;
+      // Continue processing other statements
+      continue;
     }
   }
 }

--- a/test/schemas/multimodel.prisma
+++ b/test/schemas/multimodel.prisma
@@ -1,0 +1,34 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "../target/multimodel"
+}
+
+generator json {
+  provider = "node ./index.js"
+  namespace = "PStringJson"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = ""
+}
+
+model FirstModel {
+  id Int @id @default(autoincrement())
+
+  untyped String
+  /// [TypeOne]
+  typed1 String
+  /// !['A' | 'B']
+  literal String
+}
+
+model SecondModel {
+  id Int @id @default(autoincrement())
+
+  untyped String
+  /// [TypeTwo]
+  typed2 String
+  /// !['C' | 'D']
+  literal String
+}

--- a/test/types/multimodel.test-d.ts
+++ b/test/types/multimodel.test-d.ts
@@ -1,0 +1,38 @@
+import { expectNotType, expectType } from 'tsd';
+import type { FirstModel, SecondModel } from '../target/multimodel/index';
+
+declare global {
+  export namespace PStringJson {
+    type TypeOne = 'A' | 'B';
+    type TypeTwo = 'C' | 'D';
+  }
+}
+
+expectType<FirstModel>({
+  id: 0,
+  untyped: '' as string,
+  typed1: 'A' as PStringJson.TypeOne,
+  literal: 'A' as 'A' | 'B'
+});
+
+expectNotType<FirstModel>({
+  id: 0,
+  untyped: 'Mesquita' as string,
+  typed: 'D' as string,
+  literal: 'D' as string
+});
+
+
+expectType<SecondModel>({
+  id: 0,
+  untyped: '' as string,
+  typed2: 'C' as PStringJson.TypeTwo,
+  literal: 'C' as 'C' | 'D'
+});
+
+expectNotType<SecondModel>({
+  id: 0,
+  untyped: 'Mesquita' as string,
+  typed: 'A' as string,
+  literal: 'A' as string
+});


### PR DESCRIPTION
This PR closes #396 

Problem
When the generator processes the Prisma namespace module, it iterates over all statements (type declarations) within the module. If an error occurs while processing a statement, the existing error handling logic uses a return statement inside the catch block. This causes the function to exit and stops further processing of the remaining statements. As a result, only the first model is processed correctly, and subsequent models are ignored.

Solution
To fix this issue, we need to modify the error handling in the handlePrismaModule function. Instead of using a return statement inside the catch block, we should log the error and use a continue statement to proceed to the next iteration of the loop. This ensures that all statements are processed, even if an error occurs with one of them.

A new multimodel test was added to ensure the generator is able to correctly type multiple models and it won't stop after the first one