### PR TITLE
fix: re-add support for TypeScript 5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "prisma": "^5.20||^6.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.6.2 || ^5.7.2"
   },
   "packageManager": "pnpm@9.14.4",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-json-types-generator",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Changes JsonValues to your custom typescript type",
   "keywords": ["prisma", "prisma2", "generator", "json"],
   "homepage": "https://arthur.run/prisma-json-types-generator",
@@ -42,8 +42,8 @@
     "typescript": "5.7.2"
   },
   "peerDependencies": {
-    "prisma": "^5.20||^6.0",
-    "typescript": "^5.6.2 || ^5.7.2"
+    "prisma": "^5 || ^6",
+    "typescript": "^5.6.2"
   },
   "packageManager": "pnpm@9.14.4",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: 6.0.0
         version: 6.0.0
       prisma:
-        specifier: ^5.20||^6.0
+        specifier: ^5 || ^6
         version: 5.22.0
       tslib:
         specifier: 2.8.1


### PR DESCRIPTION
Due to some unrelated changes I'm not able to update to TypeScript 5.7 yet, and while I can workaround the warnings of NPM it would be nice to not have to do this since there is no change in the package that requires TypeScript 5.7. 

It could also be considered to re-add support for earlier versions. Prisma v6 even supports TypeScript 5.1; https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6#minimum-supported-typescript-version


<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
