### PR TITLE
fix: loop through all description lines to find relevant type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-json-types-generator",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Changes JsonValues to your custom typescript type",
   "keywords": ["prisma", "prisma2", "generator", "json"],
   "homepage": "https://arthur.run/prisma-json-types-generator",

--- a/src/util/create-signature.ts
+++ b/src/util/create-signature.ts
@@ -10,12 +10,10 @@ export function createType(
     return 'unknown';
   }
 
-  /* 
-    Description can be a multi-line string like:
-      '@DtoCastType(Customization, ../../types, Customization)\n' +
-      '[CustomizationType]'
-    So we need to find the correct line to parse
-  */
+  // Description can be a multi-line string like:
+  //   '@DtoCastType(Customization, ../../types, Customization)\n' +
+  //   '[CustomizationType]'
+  // So we need to find the correct line to parse
   const lines = description.split('\n');
   let parsed = null;
   for (const line of lines) {

--- a/src/util/create-signature.ts
+++ b/src/util/create-signature.ts
@@ -6,7 +6,25 @@ export function createType(
   description: string | undefined,
   config: PrismaJsonTypesGeneratorConfig
 ) {
-  const parsed = parseTypeSyntax(description);
+  if (!description) {
+    return 'unknown';
+  }
+
+  /* 
+    Description can be a multi-line string like:
+      '@DtoCastType(Customization, ../../types, Customization)\n' +
+      '[CustomizationType]'
+    So we need to find the correct line to parse
+  */
+  // Find the last line that starts with [
+  const lines = description.split('\n');
+  let parsed = null;
+  for (const line of lines) {
+    parsed = parseTypeSyntax(line);
+    if (parsed) {
+      break;
+    }
+  }
 
   // Defaults to unknown always, config.allowAny is handled before this function
   if (!parsed) {

--- a/src/util/create-signature.ts
+++ b/src/util/create-signature.ts
@@ -16,7 +16,6 @@ export function createType(
       '[CustomizationType]'
     So we need to find the correct line to parse
   */
-  // Find the last line that starts with [
   const lines = description.split('\n');
   let parsed = null;
   for (const line of lines) {


### PR DESCRIPTION
I realized that having multi-line descriptions breaks the parsing of the type-syntax. This causes all generated types to fall back to unknown.