### PR TITLE
feat(manifest): Add Prisma >=6.6.0 Support

### DIFF
--- a/src/on-generate.ts
+++ b/src/on-generate.ts
@@ -14,7 +14,8 @@ export async function onGenerate(options: GeneratorOptions) {
 
     const config = parseConfig(options.generator.config);
 
-    const clientOutput = buildTypesFilePath(
+    let isNewClient = (prismaClient.provider.fromEnvVar || prismaClient.provider.value) == 'prisma-client';
+    const clientOutput = isNewClient ? `${prismaClient.output.value}/client.ts` : buildTypesFilePath(
       prismaClient.output.value,
       config.clientOutput,
       options.schemaPath

--- a/src/on-manifest.ts
+++ b/src/on-manifest.ts
@@ -9,7 +9,6 @@ export function onManifest(): GeneratorManifest {
     // TODO: We should change this to the real output of the generator in some way. But we cannot get its real output here
     // because we need to await the prisma client to be generated first.
     defaultOutput: './',
-    prettyName: 'Prisma Json Types Generator',
-    requiresGenerators: ['prisma-client-js']
+    prettyName: 'Prisma Json Types Generator'
   };
 }

--- a/src/util/source-path.ts
+++ b/src/util/source-path.ts
@@ -45,7 +45,8 @@ export function buildTypesFilePath(
     // schemaTarget is the full path of the Prisma schema - we need the directory
     path.dirname(schemaTarget!),
     overrideTarget,
-    // the original path may not be called index.
-    overrideTarget.endsWith('.d.ts') ? '' : 'index.d.ts'
+    // Works with `prisma-client` or `prisma-client-js`. the original path may not be called index.
+    // If it ends with .ts, we don't need to add index.d.ts because it's use `prisma-client`
+    overrideTarget.endsWith('.ts') ? '' : 'index.d.ts'
   );
 }


### PR DESCRIPTION
- Adjusted client output path logic to handle 'prisma-client' and 'prisma-client-js' cases.
- Removed unnecessary 'requiresGenerators' field from the manifest because we validate in code.
- Updated comments for clarity in source path utility.