### PR TITLE
feat: support new split-file `prisma-client` generator

### DIFF
--- a/assets/namespace.d.ts
+++ b/assets/namespace.d.ts
@@ -1,6 +1,3 @@
-// This file was overwritten by prisma-json-types-generator
-// Report any issues to https://github.com/arthurfiorette/prisma-json-types-generator
-
 declare global {
   namespace $$NAMESPACE$$ {
     // This namespace will always be empty. Definitions should be done by

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     "test": "sh ./scripts/test.sh"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^6.6.0",
+    "@prisma/generator-helper": "^6.7.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@arthurfiorette/biomejs-config": "^1.0.8",
     "@biomejs/biome": "^1.9.4",
-    "@prisma/client": "^6.6.0",
-    "@prisma/dmmf": "^6.6.0",
-    "@prisma/generator": "^6.6.0",
+    "@prisma/client": "^6.7.0",
+    "@prisma/dmmf": "^6.7.0",
+    "@prisma/generator": "^6.7.0",
     "@types/node": "^22.14.1",
     "husky": "^9.1.7",
     "source-map-support": "^0.5.21",
@@ -45,7 +45,7 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "prisma": "^6.6",
+    "prisma": "^6.7",
     "typescript": "^5.8"
   },
   "packageManager": "pnpm@9.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@prisma/generator-helper':
-        specifier: ^6.6.0
-        version: 6.6.0
+        specifier: ^6.7.0
+        version: 6.7.0
       prisma:
-        specifier: ^6.6
-        version: 6.6.0(typescript@5.8.3)
+        specifier: ^6.7
+        version: 6.7.0(typescript@5.8.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -25,13 +25,13 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       '@prisma/client':
-        specifier: ^6.6.0
-        version: 6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3)
+        specifier: ^6.7.0
+        version: 6.7.0(prisma@6.7.0(typescript@5.8.3))(typescript@5.8.3)
       '@prisma/dmmf':
-        specifier: ^6.6.0
-        version: 6.6.0
+        specifier: ^6.7.0
+        version: 6.7.0
       '@prisma/generator':
-        specifier: ^6.6.0
+        specifier: ^6.7.0
         version: 6.7.0
       '@types/node':
         specifier: ^22.14.1
@@ -281,8 +281,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@prisma/client@6.6.0':
-    resolution: {integrity: sha512-vfp73YT/BHsWWOAuthKQ/1lBgESSqYqAWZEYyTdGXyFAHpmewwWL2Iz6ErIzkj4aHbuc6/cGSsE6ZY+pBO04Cg==}
+  '@prisma/client@6.7.0':
+    resolution: {integrity: sha512-+k61zZn1XHjbZul8q6TdQLpuI/cvyfil87zqK2zpreNIXyXtpUv3+H/oM69hcsFcZXaokHJIzPAt5Z8C8eK2QA==}
     engines: {node: '>=18.18'}
     peerDependencies:
       prisma: '*'
@@ -293,35 +293,32 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/config@6.6.0':
-    resolution: {integrity: sha512-d8FlXRHsx72RbN8nA2QCRORNv5AcUnPXgtPvwhXmYkQSMF/j9cKaJg+9VcUzBRXGy9QBckNzEQDEJZdEOZ+ubA==}
+  '@prisma/config@6.7.0':
+    resolution: {integrity: sha512-di8QDdvSz7DLUi3OOcCHSwxRNeW7jtGRUD2+Z3SdNE3A+pPiNT8WgUJoUyOwJmUr5t+JA2W15P78C/N+8RXrOA==}
 
-  '@prisma/debug@6.6.0':
-    resolution: {integrity: sha512-DL6n4IKlW5k2LEXzpN60SQ1kP/F6fqaCgU/McgaYsxSf43GZ8lwtmXLke9efS+L1uGmrhtBUP4npV/QKF8s2ZQ==}
+  '@prisma/debug@6.7.0':
+    resolution: {integrity: sha512-RabHn9emKoYFsv99RLxvfG2GHzWk2ZI1BuVzqYtmMSIcuGboHY5uFt3Q3boOREM9de6z5s3bQoyKeWnq8Fz22w==}
 
-  '@prisma/dmmf@6.6.0':
-    resolution: {integrity: sha512-2LoSX0ZVwIiKck5wMCVxeGg9K9z6CULB8xyTbLF3YTvuhOp+fQozelUphaGZA9jN4MF58z6TfUXIMMPVwtxjbQ==}
+  '@prisma/dmmf@6.7.0':
+    resolution: {integrity: sha512-Nabzf5H7KUwYV/1u8R5gTQ7x3ffdPIhtxVJsjhnLOjeuem8YzVu39jOgQbiOlfOvjU4sPYkV9wEXc5tIHumdUw==}
 
-  '@prisma/engines-version@6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a':
-    resolution: {integrity: sha512-JzRaQ5Em1fuEcbR3nUsMNYaIYrOT1iMheenjCvzZblJcjv/3JIuxXN7RCNT5i6lRkLodW5ojCGhR7n5yvnNKrw==}
+  '@prisma/engines-version@6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed':
+    resolution: {integrity: sha512-EvpOFEWf1KkJpDsBCrih0kg3HdHuaCnXmMn7XFPObpFTzagK1N0Q0FMnYPsEhvARfANP5Ok11QyoTIRA2hgJTA==}
 
-  '@prisma/engines@6.6.0':
-    resolution: {integrity: sha512-nC0IV4NHh7500cozD1fBoTwTD1ydJERndreIjpZr/S3mno3P6tm8qnXmIND5SwUkibNeSJMpgl4gAnlqJ/gVlg==}
+  '@prisma/engines@6.7.0':
+    resolution: {integrity: sha512-3wDMesnOxPrOsq++e5oKV9LmIiEazFTRFZrlULDQ8fxdub5w4NgRBoxtWbvXmj2nJVCnzuz6eFix3OhIqsZ1jw==}
 
-  '@prisma/fetch-engine@6.6.0':
-    resolution: {integrity: sha512-Ohfo8gKp05LFLZaBlPUApM0M7k43a0jmo86YY35u1/4t+vuQH9mRGU7jGwVzGFY3v+9edeb/cowb1oG4buM1yw==}
+  '@prisma/fetch-engine@6.7.0':
+    resolution: {integrity: sha512-zLlAGnrkmioPKJR4Yf7NfW3hftcvqeNNEHleMZK9yX7RZSkhmxacAYyfGsCcqRt47jiZ7RKdgE0Wh2fWnm7WsQ==}
 
-  '@prisma/generator-helper@6.6.0':
-    resolution: {integrity: sha512-pKxkyb+tCb5vPaMkK6SdHkK5qkQIPDSw1T3BAfl6XWDwDwnP4f5CsJ6/VaBhtvqZ5bqfUQLvT+slaGrJQXiw9g==}
-
-  '@prisma/generator@6.6.0':
-    resolution: {integrity: sha512-UO1PFYd8Qh0LZoN/9wwAukgoDs8chLqGPho7ZBZejVKv1UpaEJvxgwS+LwlmkQ3Ay0GdsL6mjN8QxEi91xIomQ==}
+  '@prisma/generator-helper@6.7.0':
+    resolution: {integrity: sha512-z4ey7n8eUFx7Ol7RJCoEo9SVK2roy80qLXdrUFlmswcs0e/z03wDl4tpaA02BE2Yi9KCZl2Tkd6oMes81vUefA==}
 
   '@prisma/generator@6.7.0':
     resolution: {integrity: sha512-wCsD7QJn1JBKJfv5uOMhwBCvZPGerPJ3EC2HocFPFaHSzVIXLi/zNb/8gpBxervOXTbQRJ2dpqvMsJnwAnPi8A==}
 
-  '@prisma/get-platform@6.6.0':
-    resolution: {integrity: sha512-3qCwmnT4Jh5WCGUrkWcc6VZaw0JY7eWN175/pcb5Z6FiLZZ3ygY93UX0WuV41bG51a6JN/oBH0uywJ90Y+V5eA==}
+  '@prisma/get-platform@6.7.0':
+    resolution: {integrity: sha512-i9IH5lO4fQwnMLvQLYNdgVh9TK3PuWBfQd7QLk/YurnAIg+VeADcZDbmhAi4XBBDD+hDif9hrKyASu0hbjwabw==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -657,8 +654,8 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  prisma@6.6.0:
-    resolution: {integrity: sha512-SYCUykz+1cnl6Ugd8VUvtTQq5+j1Q7C0CtzKPjQ8JyA2ALh0EEJkMCS+KgdnvKW1lrxjtjCyJSHOOT236mENYg==}
+  prisma@6.7.0:
+    resolution: {integrity: sha512-vArg+4UqnQ13CVhc2WUosemwh6hr6cr6FY2uzDvCIFwH8pu8BXVv38PktoMLVjtX7sbYThxbnZF5YiR8sN2clw==}
     engines: {node: '>=18.18'}
     hasBin: true
     peerDependencies:
@@ -945,50 +942,48 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@prisma/client@6.6.0(prisma@6.6.0(typescript@5.8.3))(typescript@5.8.3)':
+  '@prisma/client@6.7.0(prisma@6.7.0(typescript@5.8.3))(typescript@5.8.3)':
     optionalDependencies:
-      prisma: 6.6.0(typescript@5.8.3)
+      prisma: 6.7.0(typescript@5.8.3)
       typescript: 5.8.3
 
-  '@prisma/config@6.6.0':
+  '@prisma/config@6.7.0':
     dependencies:
       esbuild: 0.25.3
       esbuild-register: 3.6.0(esbuild@0.25.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@prisma/debug@6.6.0': {}
+  '@prisma/debug@6.7.0': {}
 
-  '@prisma/dmmf@6.6.0': {}
+  '@prisma/dmmf@6.7.0': {}
 
-  '@prisma/engines-version@6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a': {}
+  '@prisma/engines-version@6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed': {}
 
-  '@prisma/engines@6.6.0':
+  '@prisma/engines@6.7.0':
     dependencies:
-      '@prisma/debug': 6.6.0
-      '@prisma/engines-version': 6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a
-      '@prisma/fetch-engine': 6.6.0
-      '@prisma/get-platform': 6.6.0
+      '@prisma/debug': 6.7.0
+      '@prisma/engines-version': 6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed
+      '@prisma/fetch-engine': 6.7.0
+      '@prisma/get-platform': 6.7.0
 
-  '@prisma/fetch-engine@6.6.0':
+  '@prisma/fetch-engine@6.7.0':
     dependencies:
-      '@prisma/debug': 6.6.0
-      '@prisma/engines-version': 6.6.0-53.f676762280b54cd07c770017ed3711ddde35f37a
-      '@prisma/get-platform': 6.6.0
+      '@prisma/debug': 6.7.0
+      '@prisma/engines-version': 6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed
+      '@prisma/get-platform': 6.7.0
 
-  '@prisma/generator-helper@6.6.0':
+  '@prisma/generator-helper@6.7.0':
     dependencies:
-      '@prisma/debug': 6.6.0
-      '@prisma/dmmf': 6.6.0
-      '@prisma/generator': 6.6.0
-
-  '@prisma/generator@6.6.0': {}
+      '@prisma/debug': 6.7.0
+      '@prisma/dmmf': 6.7.0
+      '@prisma/generator': 6.7.0
 
   '@prisma/generator@6.7.0': {}
 
-  '@prisma/get-platform@6.6.0':
+  '@prisma/get-platform@6.7.0':
     dependencies:
-      '@prisma/debug': 6.6.0
+      '@prisma/debug': 6.7.0
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -1321,10 +1316,10 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@6.6.0(typescript@5.8.3):
+  prisma@6.7.0(typescript@5.8.3):
     dependencies:
-      '@prisma/config': 6.6.0
-      '@prisma/engines': 6.6.0
+      '@prisma/config': 6.7.0
+      '@prisma/engines': 6.7.0
     optionalDependencies:
       fsevents: 2.3.3
       typescript: 5.8.3

--- a/src/handler/replace-object.ts
+++ b/src/handler/replace-object.ts
@@ -58,7 +58,8 @@ export function replaceObject(
         // We must ignore not found errors when no typename was found but we still
         // are replacing because of allowAny = false
         !defaultedToUnknown,
-        !defaultedToUnknown
+        !defaultedToUnknown,
+        writer.multifile ? 'PJTG.' : ''
       );
 
       // This type should be ignored by the generator

--- a/src/helpers/find-signature.ts
+++ b/src/helpers/find-signature.ts
@@ -9,11 +9,12 @@ export function findNewSignature(
   model: string,
   field: string,
   throwOnNotFound = true,
-  shouldReplaceStrings = true
+  shouldReplaceStrings = true,
+  libNamespace = ''
 ) {
   // Updates should leave optional fields
   if (isUpdateOneType(model)) {
-    typeToChange = `UpdateInput<${typeToChange}>`;
+    typeToChange = `${libNamespace}UpdateInput<${typeToChange}>`;
   }
 
   let result: string | undefined;
@@ -78,7 +79,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `TypedStringFilter<${typeToChange}> | ${typeToChange}`;
+      result = `${libNamespace}TypedStringFilter<${typeToChange}> | ${typeToChange}`;
       break;
 
     case `StringNullableFilter<"${model}"> | string | null`:
@@ -86,7 +87,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `TypedStringNullableFilter<${typeToChange}> | ${typeToChange} | null`;
+      result = `${libNamespace}TypedStringNullableFilter<${typeToChange}> | ${typeToChange} | null`;
       break;
 
     case `StringNullableListFilter<"${model}">`:
@@ -94,7 +95,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `TypedStringNullableListFilter<${typeToChange}>`;
+      result = `${libNamespace}TypedStringNullableListFilter<${typeToChange}>`;
       break;
 
     case `StringWithAggregatesFilter<"${model}"> | string`:
@@ -102,7 +103,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `TypedStringWithAggregatesFilter<${typeToChange}> | ${typeToChange}`;
+      result = `${libNamespace}TypedStringWithAggregatesFilter<${typeToChange}> | ${typeToChange}`;
       break;
 
     case `StringNullableWithAggregatesFilter<"${model}"> | string | null`:
@@ -110,7 +111,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `TypedStringNullableWithAggregatesFilter<${typeToChange}> | ${typeToChange}`;
+      result = `${libNamespace}TypedStringNullableWithAggregatesFilter<${typeToChange}> | ${typeToChange}`;
       break;
 
     case 'StringFieldUpdateOperationsInput | string':
@@ -118,7 +119,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `TypedStringFieldUpdateOperationsInput<${typeToChange}> | ${typeToChange}`;
+      result = `${libNamespace}TypedStringFieldUpdateOperationsInput<${typeToChange}> | ${typeToChange}`;
       break;
 
     case 'NullableStringFieldUpdateOperationsInput | string | null':
@@ -126,7 +127,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `TypedNullableStringFieldUpdateOperationsInput<${typeToChange}> | ${typeToChange} | null`;
+      result = `${libNamespace}TypedNullableStringFieldUpdateOperationsInput<${typeToChange}> | ${typeToChange} | null`;
       break;
 
     case `${model}Create${field}Input | string[]`:
@@ -134,7 +135,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `CreateStringArrayInput<${typeToChange}> | ${typeToChange}[]`;
+      result = `${libNamespace}CreateStringArrayInput<${typeToChange}> | ${typeToChange}[]`;
       break;
 
     case `${model}Update${field}Input | string[]`:
@@ -142,7 +143,7 @@ export function findNewSignature(
         break;
       }
 
-      result = `CreateStringArrayInput<${typeToChange}> | ${typeToChange}[]`;
+      result = `${libNamespace}CreateStringArrayInput<${typeToChange}> | ${typeToChange}[]`;
       break;
 
     //
@@ -181,17 +182,17 @@ export function findNewSignature(
 
     case `Prisma.JsonNullableListFilter<"${model}">`:
     case `JsonNullableListFilter<"${model}">`:
-      result = `NullableListFilter<${typeToChange}>`;
+      result = `${libNamespace}NullableListFilter<${typeToChange}>`;
       break;
 
     case `Prisma.${model}Update${field}Input | runtime.InputJsonValue[]`:
     case `${model}Update${field}Input | InputJsonValue[]`:
-      result = `UpdateManyInput<${typeToChange}>`;
+      result = `${libNamespace}UpdateManyInput<${typeToChange}>`;
       break;
 
     case `Prisma.${model}Create${field}Input | runtime.InputJsonValue[]`:
     case `${model}Create${field}Input | InputJsonValue[]`:
-      result = `CreateManyInput<${typeToChange}>`;
+      result = `${libNamespace}CreateManyInput<${typeToChange}>`;
       break;
 
     //

--- a/src/helpers/find-signature.ts
+++ b/src/helpers/find-signature.ts
@@ -32,9 +32,11 @@ export function findNewSignature(
     // Normal
     //
     case 'JsonValue':
+    case 'runtime.JsonValue':
     case 'Prisma.JsonValue':
     case 'InputJsonValue':
     case 'InputJsonValue | InputJsonValue':
+    case 'Prisma.JsonNullValueInput | runtime.InputJsonValue':
     case 'JsonNullValueInput | InputJsonValue':
       result = typeToChange;
       break;
@@ -147,6 +149,7 @@ export function findNewSignature(
     // Nullable
     //
     case 'JsonValue | null':
+    case 'runtime.JsonValue | null':
     case 'Prisma.JsonValue | null':
     case 'InputJsonValue | null':
     case 'InputJsonValue | InputJsonValue | null':
@@ -154,8 +157,9 @@ export function findNewSignature(
       break;
 
     case 'NullableJsonNullValueInput | InputJsonValue':
+    case 'Prisma.NullableJsonNullValueInput | runtime.InputJsonValue':
       // differentiates null in column or a json null value
-      result = `${typeToChange} | NullableJsonNullValueInput`;
+      result = `${typeToChange} | ${signature.startsWith('Prisma.') ? 'Prisma.' : ''}NullableJsonNullValueInput`;
       break;
 
     // Super complex type that strictly typing will lose functionality
@@ -166,21 +170,26 @@ export function findNewSignature(
     //
     // Array
     //
+    case 'runtime.JsonValue[]':
     case 'Prisma.JsonValue[]':
     case 'JsonValue[]':
     case 'InputJsonValue[]':
+    case `Prisma.${model}CreatelistInput | runtime.InputJsonValue[]`:
     case `${model}CreatelistInput | InputJsonValue[]`:
       result = `${typeToChange}[]`;
       break;
 
+    case `Prisma.JsonNullableListFilter<"${model}">`:
     case `JsonNullableListFilter<"${model}">`:
       result = `NullableListFilter<${typeToChange}>`;
       break;
 
+    case `Prisma.${model}Update${field}Input | runtime.InputJsonValue[]`:
     case `${model}Update${field}Input | InputJsonValue[]`:
       result = `UpdateManyInput<${typeToChange}>`;
       break;
 
+    case `Prisma.${model}Create${field}Input | runtime.InputJsonValue[]`:
     case `${model}Create${field}Input | InputJsonValue[]`:
       result = `CreateManyInput<${typeToChange}>`;
       break;

--- a/src/helpers/find-signature.ts
+++ b/src/helpers/find-signature.ts
@@ -19,13 +19,16 @@ export function findNewSignature(
 
   let result: string | undefined;
 
-  const hasSkip = signature.indexOf(PRISMA_SKIP);
-
-  // removes skip from the search
-  if (hasSkip !== -1) {
-    signature = (
-      signature.slice(0, hasSkip) + signature.slice(hasSkip + PRISMA_SKIP.length)
-    ).trim();
+  let skipVar: string | undefined;
+  for (const skipVariant of PRISMA_SKIP) {
+    const hasSkip = signature.indexOf(skipVariant);
+    // removes skip from the search
+    if (hasSkip !== -1) {
+      signature = (
+        signature.slice(0, hasSkip) + signature.slice(hasSkip + skipVariant.length)
+      ).trim();
+      skipVar = skipVariant;
+    }
   }
 
   switch (signature) {
@@ -213,8 +216,8 @@ export function findNewSignature(
   }
 
   // Add it back later
-  if (result && hasSkip !== -1) {
-    result += PRISMA_SKIP;
+  if (result && skipVar) {
+    result += skipVar;
   }
 
   return result;

--- a/src/on-generate.ts
+++ b/src/on-generate.ts
@@ -1,9 +1,11 @@
+import fs from 'node:fs/promises';
 import { join } from 'node:path';
 import type { GeneratorOptions } from '@prisma/generator';
 import ts from 'typescript';
 import { handlePrismaModule } from './handler/module';
+import { handleStatement } from './handler/statement';
 import { extractPrismaModels } from './helpers/dmmf';
-import { parseConfig } from './util/config';
+import { type PrismaJsonTypesGeneratorConfig, parseConfig } from './util/config';
 import { DeclarationWriter } from './util/declaration-writer';
 import { findPrismaClientGenerator } from './util/prisma-generator';
 import { buildTypesFilePath } from './util/source-path';
@@ -17,28 +19,54 @@ export async function onGenerate(options: GeneratorOptions) {
 
     const isNewClient =
       (prismaClient.provider.fromEnvVar || prismaClient.provider.value) === 'prisma-client';
+    if (isNewClient) {
+      try {
+        const modelsFolder = join(prismaClient.output.value, 'models');
+        const stat = await fs.stat(modelsFolder);
+        if (stat.isDirectory()) {
+          // Models are split into multiple files starting in prisma@6.7
+          for (const modelFile of await fs.readdir(modelsFolder)) {
+            await handleDeclarationFile(join(modelsFolder, modelFile), config, options, false);
+          }
+          return;
+        }
+      } catch {}
+    }
+
     const clientOutput = isNewClient
       ? join(prismaClient.output.value, 'client.ts')
       : buildTypesFilePath(prismaClient.output.value, config.clientOutput, options.schemaPath);
+    await handleDeclarationFile(clientOutput, config, options);
+  } catch (error) {
+    console.error(error);
+  }
+}
 
-    const writer = new DeclarationWriter(clientOutput, config);
+async function handleDeclarationFile(
+  filepath: string,
+  config: PrismaJsonTypesGeneratorConfig,
+  options: GeneratorOptions,
+  expectingNamespace = true
+) {
+  const writer = new DeclarationWriter(filepath, config);
 
-    // Reads the prisma declaration file content.
-    await writer.load();
+  // Reads the prisma declaration file content.
+  await writer.load();
 
-    const tsSource = ts.createSourceFile(
-      writer.filepath,
-      writer.content,
-      ts.ScriptTarget.ESNext,
-      true,
-      ts.ScriptKind.TS
-    );
+  const tsSource = ts.createSourceFile(
+    writer.filepath,
+    writer.content,
+    ts.ScriptTarget.ESNext,
+    true,
+    ts.ScriptKind.TS
+  );
 
-    const { typeToNameMap, modelMap, knownNoOps } = extractPrismaModels(options.dmmf);
+  const { typeToNameMap, modelMap, knownNoOps } = extractPrismaModels(options.dmmf);
 
-    // Handles the prisma namespace.
-    tsSource.forEachChild((child) => {
-      try {
+  // Handles the prisma namespace.
+  tsSource.forEachChild((child) => {
+    try {
+      if (expectingNamespace) {
         if (child.kind === ts.SyntaxKind.ModuleDeclaration) {
           handlePrismaModule(
             child as ts.ModuleDeclaration,
@@ -49,13 +77,22 @@ export async function onGenerate(options: GeneratorOptions) {
             config
           );
         }
-      } catch (error) {
-        console.error(error);
+      } else {
+        if (ts.isStatement(child)) {
+          handleStatement(
+            child as ts.Statement,
+            writer,
+            modelMap,
+            typeToNameMap,
+            knownNoOps,
+            config
+          );
+        }
       }
-    });
+    } catch (error) {
+      console.error(error);
+    }
+  });
 
-    await writer.save();
-  } catch (error) {
-    console.error(error);
-  }
+  await writer.save();
 }

--- a/src/on-generate.ts
+++ b/src/on-generate.ts
@@ -27,11 +27,7 @@ export async function onGenerate(options: GeneratorOptions) {
         if (stat.isDirectory()) {
           // Models are split into multiple files starting in prisma@6.7
           for (const modelFile of await fs.readdir(modelsFolder)) {
-            try {
-              await handleDeclarationFile(join(modelsFolder, modelFile), config, options, true);
-            } catch (error) {
-              console.error(error);
-            }
+            await handleDeclarationFile(join(modelsFolder, modelFile), config, options, true);
           }
 
           await fs.writeFile(
@@ -40,7 +36,12 @@ export async function onGenerate(options: GeneratorOptions) {
           );
           return;
         }
-      } catch {}
+      } catch (e: any) {
+        // Ignore ENOENT since that likely means the `models` folder could not be found, indicating a <= v6.6 file structure
+        if (!('code' in e) || e.code !== 'ENOENT') {
+          console.error(e);
+        }
+      }
     }
 
     const clientOutput = isNewClient

--- a/src/on-generate.ts
+++ b/src/on-generate.ts
@@ -6,6 +6,7 @@ import { handlePrismaModule } from './handler/module';
 import { handleStatement } from './handler/statement';
 import { extractPrismaModels } from './helpers/dmmf';
 import { type PrismaJsonTypesGeneratorConfig, parseConfig } from './util/config';
+import { LIB_HEADER } from './util/constants';
 import { DeclarationWriter, getNamespacePrelude } from './util/declaration-writer';
 import { findPrismaClientGenerator } from './util/prisma-generator';
 import { buildTypesFilePath } from './util/source-path';
@@ -35,7 +36,7 @@ export async function onGenerate(options: GeneratorOptions) {
 
           await fs.writeFile(
             join(prismaClient.output.value, 'pjtg.ts'),
-            await getNamespacePrelude(config.namespace)
+            `${LIB_HEADER}\n${await getNamespacePrelude(config.namespace)}`
           );
           return;
         }

--- a/src/on-generate.ts
+++ b/src/on-generate.ts
@@ -26,7 +26,11 @@ export async function onGenerate(options: GeneratorOptions) {
         if (stat.isDirectory()) {
           // Models are split into multiple files starting in prisma@6.7
           for (const modelFile of await fs.readdir(modelsFolder)) {
-            await handleDeclarationFile(join(modelsFolder, modelFile), config, options, true);
+            try {
+              await handleDeclarationFile(join(modelsFolder, modelFile), config, options, true);
+            } catch (error) {
+              console.error(error);
+            }
           }
 
           await fs.writeFile(

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -8,3 +8,10 @@ export const NAMESPACE_PATH = path.resolve(__dirname, '../../assets/namespace.d.
 
 /** https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/null-and-undefined#strict-undefined-checks-preview-feature */
 export const PRISMA_SKIP = ['| runtime.Types.Skip', '| $Types.Skip'];
+
+/** Header to prepend to modified files */
+export const MODIFIED_HEADER = `// This file was overwritten by prisma-json-types-generator
+// Report any issues to https://github.com/arthurfiorette/prisma-json-types-generator`;
+
+/** Header to prepend to generated pjtg.ts */
+export const LIB_HEADER = MODIFIED_HEADER.replace('overwritten', 'generated');

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -7,4 +7,4 @@ export const PRISMA_NAMESPACE_NAME = 'Prisma';
 export const NAMESPACE_PATH = path.resolve(__dirname, '../../assets/namespace.d.ts');
 
 /** https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/null-and-undefined#strict-undefined-checks-preview-feature */
-export const PRISMA_SKIP = '| $Types.Skip';
+export const PRISMA_SKIP = ['| runtime.Types.Skip', '| $Types.Skip'];

--- a/src/util/declaration-writer.ts
+++ b/src/util/declaration-writer.ts
@@ -26,10 +26,12 @@ export class DeclarationWriter {
   private changeset: TextDiff[] = [];
 
   async template() {
+    const modifiedHeader = `// This file was overwritten by prisma-json-types-generator
+// Report any issues to https://github.com/arthurfiorette/prisma-json-types-generator`;
     if (this.multifile) {
-      return `import type * as PJTG from '../pjtg';\n${this.content}`;
+      return `${modifiedHeader}\nimport type * as PJTG from '../pjtg';\n${this.content}`;
     }
-    return `${await getNamespacePrelude(this.options.namespace)}\n${this.content}`;
+    return `${modifiedHeader}\n${await getNamespacePrelude(this.options.namespace)}\n${this.content}`;
   }
 
   /** Loads the original file of sourcePath into memory. */

--- a/src/util/declaration-writer.ts
+++ b/src/util/declaration-writer.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import type { PrismaJsonTypesGeneratorConfig } from './config';
-import { NAMESPACE_PATH } from './constants';
+import { MODIFIED_HEADER, NAMESPACE_PATH } from './constants';
 import { PrismaJsonTypesGeneratorError } from './error';
 
 /** A changes made in the original file to help adjust any future coordinates of texts */
@@ -26,12 +26,10 @@ export class DeclarationWriter {
   private changeset: TextDiff[] = [];
 
   async template() {
-    const modifiedHeader = `// This file was overwritten by prisma-json-types-generator
-// Report any issues to https://github.com/arthurfiorette/prisma-json-types-generator`;
     if (this.multifile) {
-      return `${modifiedHeader}\nimport type * as PJTG from '../pjtg';\n${this.content}`;
+      return `${MODIFIED_HEADER}\nimport type * as PJTG from '../pjtg';\n${this.content}`;
     }
-    return `${modifiedHeader}\n${await getNamespacePrelude(this.options.namespace)}\n${this.content}`;
+    return `${MODIFIED_HEADER}\n${await getNamespacePrelude(this.options.namespace)}\n${this.content}`;
   }
 
   /** Loads the original file of sourcePath into memory. */

--- a/test/types/normal-prisma-client.test-d.ts
+++ b/test/types/normal-prisma-client.test-d.ts
@@ -1,5 +1,6 @@
 import { expectAssignable, expectNotAssignable } from 'tsd';
-import type { Model, UpdateManyInput } from '../target/normal-prisma-client/index';
+import type { Model } from '../target/normal-prisma-client/index';
+import type { UpdateManyInput } from '../target/normal-prisma-client/models';
 
 declare global {
   export namespace PNormalPrismaClientJson {

--- a/test/types/normal-prisma-client.test-d.ts
+++ b/test/types/normal-prisma-client.test-d.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectNotAssignable } from 'tsd';
 import type { Model } from '../target/normal-prisma-client/index';
-import type { UpdateManyInput } from '../target/normal-prisma-client/models';
+import type { UpdateManyInput } from '../target/normal-prisma-client/pjtg';
 
 declare global {
   export namespace PNormalPrismaClientJson {


### PR DESCRIPTION
This PR adds support for the new [split-file client](https://www.prisma.io/docs/orm/prisma-schema/overview/generators#output-splitting-and-importing-types) mode of the `prisma-client` generator introduced in [Prisma v6.7.0](https://github.com/prisma/prisma/releases/tag/6.7.0).