### PR TITLE
Fix TypeScript errors in the new 6.7.0 ESM generator.

### DIFF
--- a/src/util/declaration-writer.ts
+++ b/src/util/declaration-writer.ts
@@ -27,7 +27,7 @@ export class DeclarationWriter {
 
   async template() {
     if (this.multifile) {
-      return `${MODIFIED_HEADER}\nimport type * as PJTG from '../pjtg';\n${this.content}`;
+      return `${MODIFIED_HEADER}\n// @ts-nocheck\nimport type * as PJTG from '../pjtg.ts';\n${this.content}`;
     }
     return `${MODIFIED_HEADER}\n${await getNamespacePrelude(this.options.namespace)}\n${this.content}`;
   }


### PR DESCRIPTION
When using ESM modules, `"module": "nodenext"` and `"moduleResolution": "nodenext"` in your `tsconfig.json`, extensions are required. This PR adds the extension to the injected import.