### PR TITLE
fix: Add type on string

### DIFF
--- a/src/helpers/find-signature.ts
+++ b/src/helpers/find-signature.ts
@@ -53,6 +53,7 @@ export function findNewSignature(
     //
     // String
     //
+    case 'Prisma.StringFieldUpdateOperationsInput | string':
     case 'string':
       if (!shouldReplaceStrings) {
         break;


### PR DESCRIPTION
Fixed if one type a string, the other json stop working.

Example:

## Doesn't Work
```prisma
model pages {
  id         String   @id
  /// [pay_provider] 
  pay_provider    String 
  /// [ats_config] 
  ats_config          Json?
}
```

## I dont know why Work???
```prisma
model pages {
  id         String   @id
  d1    json
  d2    String

  /// [pages.pay_provider] 
  pay_provider    String 
  /// [pages.ats_config] 
  ats_config          Json?
}
```