### PR TITLE
fix: add missing `UpdateManyWithout` type convertion for new client

### DIFF
--- a/src/helpers/regex.ts
+++ b/src/helpers/regex.ts
@@ -26,7 +26,8 @@ export function createRegexForType(name: string) {
     // new RegExp(`^${name}(?:Unchecked)?UpdateInput$`, 'm'),
     // new RegExp(`^${name}(?:Unchecked)?UpdateManyInput$`, 'm'),
     // new RegExp(`^${name}(?:Unchecked)?UpdateManyMutationInput$`, 'm'),
-    new RegExp(`^${name}(?:Unchecked)?UpdateWithout(?:\\w+?)Input$`, 'm')
+    new RegExp(`^${name}(?:Unchecked)?UpdateWithout(?:\\w+?)Input$`, 'm'),
+    new RegExp(`^${name}(?:Unchecked)?UpdateManyWithout(?:\\w+?)Input$`, 'm')
   ];
 }
 
@@ -61,7 +62,11 @@ export function extractBaseNameFromRelationType(typeName: string): string | null
 
 /** If the provided type is a update one variant */
 export function isUpdateOneType(type: string) {
-  return type.match(/UpdateInput$/m) || type.match(/UpdateWithout(?:\w+?)Input$/m);
+  return (
+    type.match(/UpdateInput$/m) ||
+    type.match(/UpdateWithout(?:\w+?)Input$/m) ||
+    type.match(/UpdateManyWithout(?:\w+?)Input$/m)
+  );
 }
 
 /**

--- a/src/helpers/regex.ts
+++ b/src/helpers/regex.ts
@@ -34,6 +34,7 @@ export function extractBaseNameFromRelationType(typeName: string): string | null
   const createWithoutRegex = /^(.+?)(?:Unchecked)?CreateWithout(?:\w+?)Input$/m;
   const createManyRegex = /^(.+?)(?:Unchecked)?CreateMany(?:\w+?)Input$/m;
   const updateWithoutRegex = /^(.+?)(?:Unchecked)?UpdateWithout(?:\w+?)Input$/m;
+  const updateManyWithoutRegex = /^(.+?)(?:Unchecked)?UpdateManyWithout(?:\w+?)Input$/m;
 
   let match = typeName.match(createWithoutRegex);
   if (match?.[1]) {
@@ -46,6 +47,11 @@ export function extractBaseNameFromRelationType(typeName: string): string | null
   }
 
   match = typeName.match(updateWithoutRegex);
+  if (match?.[1]) {
+    return match[1];
+  }
+
+  match = typeName.match(updateManyWithoutRegex);
   if (match?.[1]) {
     return match[1];
   }

--- a/test/schemas/normal-prisma-client.prisma
+++ b/test/schemas/normal-prisma-client.prisma
@@ -26,4 +26,16 @@ model Model {
 
   /// [List]
   list Json[]
+
+  models SubModel[]
+}
+
+model SubModel {
+  id Int @id @default(autoincrement())
+
+  /// [Simple]
+  simple Json
+
+  modelId Int
+  model   Model @relation(fields: [modelId], references: [id])
 }

--- a/test/types/normal-prisma-client.test-d.ts
+++ b/test/types/normal-prisma-client.test-d.ts
@@ -1,5 +1,6 @@
 import { expectAssignable, expectNotAssignable } from 'tsd';
 import type { Model } from '../target/normal-prisma-client/client';
+import type { SubModelUncheckedUpdateManyWithoutModelInput } from '../target/normal-prisma-client/models';
 import type { UpdateManyInput } from '../target/normal-prisma-client/pjtg';
 
 declare global {
@@ -66,6 +67,8 @@ expectAssignable<UpdateManyInput<Model['list'][number]>>({
   set: [3, 3, 3]
 });
 
+expectAssignable<SubModelUncheckedUpdateManyWithoutModelInput['simple']>(1);
+
 expectNotAssignable<Model>({
   id: 0,
   simple: '1',
@@ -113,3 +116,5 @@ expectNotAssignable<UpdateManyInput<Model['list'][number]>>({
 expectNotAssignable<UpdateManyInput<Model['list'][number]>>({
   set: ['3,3,3']
 });
+
+expectNotAssignable<SubModelUncheckedUpdateManyWithoutModelInput['simple']>(2);


### PR DESCRIPTION
<!--
Thank you for your pull request! Please provide a brief description above and review the requirements below.

Bug fixes and new features should include tests.

By submitting this contribution, I certify that:

* (a) I created it entirely or have the right to submit it under the project's open source license.
* (b) If based on prior work, I have the right to submit it with modifications under the same or an allowed license.
* (c) If provided by someone else, they certified (a), (b), or (c), and I have not modified it.
* (d) I understand this contribution is public, and a record of it (including personal details I submit) may be maintained indefinitely and redistributed under the project's license.
-->

This pull request fixes the issue with missing`UpdateManyWithout` type conversion in the generator logic.

- Updated the regex and extraction logic to support `UpdateManyWithout` types.
- Added a new model and relation in the test schema.
- Introduced new type tests to validate the fix.


