### PR TITLE
fix: very slow string replacement in large declaration files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
   "extends": ["@arthurfiorette/biomejs-config"],
   "files": {
     "includes": ["**", "!**/test/target"]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint-fix": "biome check --write --unsafe .",
     "prepare": "husky",
     "start": "node dist/bin.js",
-    "test": "sh ./scripts/test.sh"
+    "test": "sh ./scripts/test.sh",
+    "test-unit": "pnpm tsx --test test/unit/**/*.test.ts"
   },
   "dependencies": {
     "@prisma/generator-helper": "^6.16.1",
@@ -50,7 +51,8 @@
     "@types/semver": "^7.7.1",
     "husky": "^9.1.7",
     "prisma": "^6.16.1",
-    "tsd": "^0.33.0"
+    "tsd": "^0.33.0",
+    "tsx": "^4.20.6"
   },
   "peerDependencies": {
     "@prisma/client": "^6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       tsd:
         specifier: ^0.33.0
         version: 0.33.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
 
 packages:
 
@@ -115,6 +118,162 @@ packages:
   '@biomejs/cli-win32-x64@2.2.5':
     resolution: {integrity: sha512-F/jhuXCssPFAuciMhHKk00xnCAxJRS/pUzVfXYmOMUp//XW7mO6QeCjsjvnm8L4AO/dG2VOB0O+fJPiJ2uXtIw==}
     engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -316,6 +475,11 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   eslint-formatter-pretty@4.1.0:
     resolution: {integrity: sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==}
     engines: {node: '>=10'}
@@ -345,8 +509,16 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
@@ -603,6 +775,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -683,6 +858,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-fest@0.18.1:
     resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
     engines: {node: '>=10'}
@@ -762,6 +942,84 @@ snapshots:
     optional: true
 
   '@biomejs/cli-win32-x64@2.2.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
     optional: true
 
   '@jest/schemas@29.6.3':
@@ -950,6 +1208,35 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
   eslint-formatter-pretty@4.1.0:
     dependencies:
       '@types/eslint': 7.29.0
@@ -990,7 +1277,14 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
+
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   giget@2.0.0:
     dependencies:
@@ -1237,6 +1531,8 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -1313,6 +1609,13 @@ snapshots:
       read-pkg-up: 7.0.1
 
   tslib@2.8.1: {}
+
+  tsx@4.20.6:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-fest@0.18.1: {}
 

--- a/src/util/text-changes.ts
+++ b/src/util/text-changes.ts
@@ -1,0 +1,47 @@
+/** A changes made in the original file to help adjust any future coordinates of texts */
+export interface TextDiff {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/**
+ * Applies multiple text changes to a string efficiently.
+ * Uses array-based approach to avoid quadratic string concatenation.
+ *
+ * @param content The original text content
+ * @param changes Array of changes to apply
+ * @returns The text with all changes applied
+ */
+export function applyTextChanges(content: string, changes: TextDiff[]): string {
+  if (changes.length === 0) {
+    return content;
+  }
+
+  // Sort the changes by their start index to apply them in order
+  const sortedChanges = [...changes].sort((a, b) => a.start - b.start);
+
+  const segments: string[] = [];
+  let lastEnd = 0;
+
+  for (const change of sortedChanges) {
+    // Add the unchanged content before this change
+    if (change.start > lastEnd) {
+      segments.push(content.substring(lastEnd, change.start));
+    }
+
+    // Add the replacement text
+    segments.push(change.text);
+
+    // Update the position for the next iteration
+    lastEnd = change.end;
+  }
+
+  // Add any remaining content after the last change
+  if (lastEnd < content.length) {
+    segments.push(content.substring(lastEnd));
+  }
+
+  // Join all segments once at the end
+  return segments.join('');
+}

--- a/test/unit/text-changes.test.ts
+++ b/test/unit/text-changes.test.ts
@@ -1,0 +1,203 @@
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { applyTextChanges, type TextDiff } from '../../src/util/text-changes.js';
+
+describe('applyTextChanges - precise text replacement', () => {
+  test('should return unchanged content when no replacements are made', () => {
+    const content = 'The quick brown fox jumps over the lazy dog';
+    const changes: TextDiff[] = [];
+
+    const result = applyTextChanges(content, changes);
+
+    assert.equal(result, 'The quick brown fox jumps over the lazy dog');
+  });
+
+  test('should replace exact substring without affecting surrounding text', () => {
+    const content = 'The quick brown fox jumps over the lazy dog';
+    const changes: TextDiff[] = [
+      { start: 10, end: 19, text: 'red cat' } // Replace "brown fox"
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'The quick red cat jumps over the lazy dog');
+  });
+
+  test('should handle replacement at string start', () => {
+    const content = 'Original text here';
+    const changes: TextDiff[] = [{ start: 0, end: 8, text: 'Modified' }];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'Modified text here');
+  });
+
+  test('should handle replacement at string end', () => {
+    const content = 'Text goes here';
+    const changes: TextDiff[] = [{ start: 10, end: 14, text: 'there' }];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'Text goes there');
+  });
+
+  test('should handle zero-length insertion correctly', () => {
+    const content = 'Hello world';
+    const changes: TextDiff[] = [
+      { start: 5, end: 5, text: ' beautiful' } // Insert at position 5
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'Hello beautiful world');
+  });
+
+  test('should handle complete deletion correctly', () => {
+    const content = 'Remove this part from text';
+    const changes: TextDiff[] = [
+      { start: 7, end: 17, text: '' } // Delete "this part "
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'Remove from text');
+  });
+
+  test('should apply multiple non-overlapping replacements correctly', () => {
+    const content = 'First second third fourth';
+    const changes: TextDiff[] = [
+      { start: 19, end: 25, text: 'FOURTH' }, // "fourth" -> "FOURTH"
+      { start: 6, end: 12, text: 'SECOND' }, // "second" -> "SECOND"
+      { start: 0, end: 5, text: 'FIRST' } // "First" -> "FIRST"
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'FIRST SECOND third FOURTH');
+  });
+
+  test('should handle adjacent replacements without gaps or overlaps', () => {
+    const content = 'abcdefghij';
+    const changes: TextDiff[] = [
+      { start: 0, end: 3, text: 'ABC' }, // "abc" -> "ABC"
+      { start: 3, end: 6, text: 'DEF' }, // "def" -> "DEF"
+      { start: 6, end: 10, text: 'GHIJ' } // "ghij" -> "GHIJ"
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'ABCDEFGHIJ');
+  });
+
+  test('should handle unicode characters correctly', () => {
+    const content = 'Test 🌍 content';
+    const emojiStart = content.indexOf('🌍');
+    const emojiEnd = emojiStart + '🌍'.length;
+
+    const changes: TextDiff[] = [{ start: emojiStart, end: emojiEnd, text: '🌎' }];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'Test 🌎 content');
+  });
+
+  test('should handle newlines and whitespace precisely', () => {
+    const content = 'Line 1\n  Line 2\n    Line 3';
+    const changes: TextDiff[] = [
+      { start: 9, end: 15, text: 'Modified' } // Replace "Line 2"
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'Line 1\n  Modified\n    Line 3');
+  });
+
+  test('should handle overlapping replacements by start position order', () => {
+    const content = 'abcdefghij';
+    const changes: TextDiff[] = [
+      { start: 5, end: 8, text: 'XYZ' }, // "fgh" -> "XYZ"
+      { start: 2, end: 6, text: 'MNOP' } // "cdef" -> "MNOP"
+    ];
+
+    const result = applyTextChanges(content, changes);
+    // Should apply in start position order: first MNOP (2-6), then XYZ affects what's left
+    assert.equal(result, 'abMNOPXYZij');
+  });
+
+  test('should preserve content outside of replacements exactly', () => {
+    const content =
+      '/* Important comment */\nexport interface User {\n  id: JsonValue;\n  name: string;\n}\n// End comment';
+    const jsonValuePos = content.indexOf('JsonValue');
+    const changes: TextDiff[] = [
+      { start: jsonValuePos, end: jsonValuePos + 'JsonValue'.length, text: 'UserID' }
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert(result.includes('/* Important comment */'));
+    assert(result.includes('export interface User {'));
+    assert(result.includes('id: UserID;'));
+    assert(result.includes('name: string;'));
+    assert(result.includes('// End comment'));
+    assert(!result.includes('JsonValue'));
+  });
+
+  test('should handle empty content', () => {
+    const content = '';
+    const changes: TextDiff[] = [];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, '');
+  });
+
+  test('should handle single character replacement', () => {
+    const content = 'a';
+    const changes: TextDiff[] = [{ start: 0, end: 1, text: 'b' }];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'b');
+  });
+
+  test('should handle multiple insertions at same position', () => {
+    const content = 'Hello world';
+    const changes: TextDiff[] = [
+      { start: 5, end: 5, text: ' beautiful' },
+      { start: 5, end: 5, text: ' amazing' }
+    ];
+
+    const result = applyTextChanges(content, changes);
+    // Both insertions should appear in order they were added
+    assert.equal(result, 'Hello beautiful amazing world');
+  });
+
+  test('should not modify original content or changes array', () => {
+    const content = 'Original content';
+    const changes: TextDiff[] = [{ start: 0, end: 8, text: 'Modified' }];
+    const originalChanges = [...changes];
+
+    const result = applyTextChanges(content, changes);
+
+    // Original parameters should remain unchanged
+    assert.equal(content, 'Original content');
+    assert.deepEqual(changes, originalChanges);
+    assert.equal(result, 'Modified content');
+  });
+
+  test('should handle complex replacement scenario', () => {
+    const content = 'function oldName(param1, param2) { return oldName.helper(param1, param2); }';
+    const firstOld = content.indexOf('oldName');
+    const secondOld = content.indexOf('oldName', firstOld + 1);
+
+    const changes: TextDiff[] = [
+      { start: firstOld, end: firstOld + 'oldName'.length, text: 'newName' },
+      { start: secondOld, end: secondOld + 'oldName'.length, text: 'newName' }
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(
+      result,
+      'function newName(param1, param2) { return newName.helper(param1, param2); }'
+    );
+  });
+
+  test('should handle edge case with replacement at exact content boundaries', () => {
+    const content = 'start middle end';
+    const changes: TextDiff[] = [
+      { start: 0, end: 5, text: 'BEGIN' }, // "start" -> "BEGIN"
+      { start: 13, end: 16, text: 'FINISH' } // "end" -> "FINISH"
+    ];
+
+    const result = applyTextChanges(content, changes);
+    assert.equal(result, 'BEGIN middle FINISH');
+  });
+});


### PR DESCRIPTION
Hi, we've been using this great tool for a long time, but recently we observed it takes a lot of time to run the plugin.

The plugin was running on our codebase for `20s`.

After whole afternoon spend on rewriting the project to regular expresions to replace ts compiler and AST lookup I've found out that what is acutally slow is replacement of the types in the declaration file 🤡 

Turns out `slice` / `substring` toghether with concatenation and allocating new string in each iteration is very slow on long strings as it has to copy all characters multiple times. 
ChatGTP suggested the solution, and as a result it now takes just `1s` to run the plugin 🥳 

My poc with regexps was even faster, I mean extraction was faster and it overall took 500ms, but traversing AST is defenitely  easier to maintain, so I gave up on that. 

Btw tests on `main` are failing, I'm not sure how to proceed. 

before

<img width="600" height="60" alt="image" src="https://github.com/user-attachments/assets/09f0bccc-c8b8-46c9-8521-0221a609a2ba" />


after

<img width="610" height="74" alt="image" src="https://github.com/user-attachments/assets/c2d06306-da19-4dba-8f30-1b7f56c46389" />
