### PR TITLE
fix: enable processing for GroupBy and Aggregate types

### DIFF
--- a/src/helpers/regex.ts
+++ b/src/helpers/regex.ts
@@ -9,10 +9,10 @@ export function createRegexForType(name: string) {
     // new RegExp(`^${name}CountOrderByAggregateInput$`, 'm'), `SortOrder` fields
     // new RegExp(`^${name}CountAggregateInputType$`, 'm'), `true` fields
 
-    // new RegExp(`^${name}Group$`, 'm'),
-    // new RegExp(`^${name}GroupByOutputType$`, 'm'),
-    // new RegExp(`^${name}OrderByWithRelationInput$`, 'm'), `SortOrder` fields
-    // new RegExp(`^${name}OrderByWithAggregationInput$`, 'm'), `SortOrder` fields
+    new RegExp(`^${name}Group$`, 'm'),
+    new RegExp(`^${name}GroupByOutputType$`, 'm'),
+    new RegExp(`^${name}OrderByWithRelationInput$`, 'm'),
+    new RegExp(`^${name}OrderByWithAggregationInput$`, 'm'),
 
     // new RegExp(`^${name}(?:Scalar)?Where$`, 'm'),
     // new RegExp(`^${name}(?:Scalar)?WhereInput$`, 'm'),


### PR DESCRIPTION
The generator was ignoring GroupBy and Aggregate types because the corresponding regex patterns were commented out in `src/helpers/regex.ts`. This PR enables processing for these types, ensuring that JSON fields in `groupBy` results are correctly typed.