### PR TITLE
feat: use @typescript/typescript6 for the compiler API to support TypeScript 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@prisma/generator-helper": "^7.8.0",
+    "@typescript/typescript6": "^6.0.0",
     "semver": "^7.7.4",
     "try": "^1.0.3",
     "tslib": "^2.8.1"
@@ -53,12 +54,12 @@
     "husky": "^9.1.7",
     "prisma": "^7.8.0",
     "tsd": "^0.33.0",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "@prisma/client": "^7.8.0",
-    "prisma": "^7.8.0",
-    "typescript": "^6.0.3"
+    "prisma": "^7.8.0"
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@prisma/generator-helper':
         specifier: ^7.8.0
         version: 7.8.0
+      '@typescript/typescript6':
+        specifier: ^6.0.0
+        version: 6.0.1
       semver:
         specifier: ^7.7.4
         version: 7.8.1
@@ -23,9 +26,6 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
     devDependencies:
       '@arthurfiorette/biomejs-config':
         specifier: ^2.0.1
@@ -57,6 +57,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -496,6 +499,10 @@ packages:
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@typescript/typescript6@6.0.1':
+    resolution: {integrity: sha512-JbesA1Y3wSOYpcw4b4XvG8KCk9AaStATxk1Vmc1qY0Y30fjovvcuRXX2fJ8eC2JRycKQi7V1VYKUljSVBJUzZA==}
+    hasBin: true
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1515,6 +1522,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/semver@7.7.1': {}
+
+  '@typescript/typescript6@6.0.1':
+    dependencies:
+      typescript: 6.0.3
 
   ajv@8.18.0:
     dependencies:

--- a/src/handler/model-payload.ts
+++ b/src/handler/model-payload.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 import type { PrismaEntity } from '../helpers/dmmf';
 import type { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import type { DeclarationWriter } from '../util/declaration-writer';

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -1,5 +1,5 @@
+import ts from '@typescript/typescript6';
 import { Result } from 'try';
-import ts from 'typescript';
 import type { PrismaEntity } from '../helpers/dmmf';
 import type { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import { PRISMA_NAMESPACE_NAME } from '../util/constants';

--- a/src/handler/replace-object.ts
+++ b/src/handler/replace-object.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 import type { PrismaEntity } from '../helpers/dmmf';
 import { findNewSignature } from '../helpers/find-signature';
 import { parseTypeSyntax } from '../helpers/type-parser';

--- a/src/handler/statement.ts
+++ b/src/handler/statement.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 import type { PrismaEntity } from '../helpers/dmmf';
 import { extractBaseNameFromRelationType } from '../helpers/regex';
 import type { PrismaJsonTypesGeneratorConfig } from '../util/config';

--- a/src/on-generate.ts
+++ b/src/on-generate.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import { join } from 'node:path';
 import type { GeneratorOptions } from '@prisma/generator';
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 import { handlePrismaModule } from './handler/module';
 import { handleStatement } from './handler/statement';
 import { extractPrismaModels } from './helpers/dmmf';


### PR DESCRIPTION
Hit this while upgrading a project to the TypeScript 7 RC (`typescript@7.0.1-rc`): `prisma generate` crashes with `ERR_PACKAGE_PATH_NOT_EXPORTED`, because TS 7 (the native compiler) no longer ships the JS API this generator loads via `import ts from 'typescript'`.

Small fix — import the compiler API from `@typescript/typescript6` (Microsoft's v6 JS-API compat package, as [recommended in the 7.0 RC announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/#running-side-by-side-with-typescript-6.0)) instead of relying on the consumer's `typescript` peer. The generator then always has the API it needs, whatever TypeScript version the project itself is on.

This unblocks anyone trying the 7.0 RC today, and avoids a hard break for everyone once 7.0 ships as `latest`.

Build, unit tests and the full e2e schema/tsd suite pass.