### PR TITLE
feat: support TypeScript 7 via optional @typescript/typescript6 fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,41 @@ jobs:
         env:
           # Prisma breaks when running tests in parallel
           PJTG_SEQUENTIAL_TESTS: 1
+
+  typescript-7:
+    name: CI typescript@7
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup node and restore cached dependencies
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Build code
+        run: pnpm build
+
+      # Swap in TypeScript 7 after building so the generator resolves the
+      # compiler API through the @typescript/typescript6 fallback at runtime.
+      # minimum-release-age is bypassed because it silently keeps the previous
+      # version when the requested one is too recent, voiding this job.
+      - name: Install TypeScript 7
+        run: |
+          pnpm --config.minimum-release-age=0 add -D typescript@^7.0.0
+          node -e "const v = require('typescript/package.json').version; if (!v.startsWith('7.')) { throw new Error('expected typescript 7, got ' + v) }"
+
+      - name: E2E tests
+        run: pnpm test-e2e
+        env:
+          # Prisma breaks when running tests in parallel
+          PJTG_SEQUENTIAL_TESTS: 1

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <br />
 
 > [!IMPORTANT]  
-> `prisma-json-types-generator@5+` only supports Prisma v7 and TypeScript v6.
+> `prisma-json-types-generator@5+` only supports Prisma v7 and TypeScript v6/v7. TypeScript 7 projects also need `@typescript/typescript6`, see [Installation](#installation).
 
 <br />
 
@@ -71,6 +71,16 @@ Install the package as a development dependency in your project.
 ```bash
 npm install -D prisma-json-types-generator
 ```
+
+### TypeScript 7
+
+TypeScript 7 (the native compiler) no longer ships the JS compiler API this generator uses to parse the generated client declarations. If your project uses `typescript@7`, also install [`@typescript/typescript6`](https://www.npmjs.com/package/@typescript/typescript6), Microsoft's official compatibility package:
+
+```bash
+npm install -D @typescript/typescript6
+```
+
+Your project keeps compiling with TypeScript 7; the compatibility package is only used by this generator. On TypeScript 6, nothing changes and no extra package is needed.
 
 ## Install the Skill
 
@@ -323,7 +333,7 @@ It then traverses this AST, and for each property signature in a model, it cross
 ## Limitations
 
 - **Complex Filters:** To preserve functionality, types like `JsonFilter` and `JsonWithAggregatesFilter` remain untyped.
-- **Version Support:** `prisma-json-types-generator@5+` only supports Prisma v7 and TypeScript v6.
+- **Version Support:** `prisma-json-types-generator@5+` only supports Prisma v7 and TypeScript v6/v7 (v7 requires `@typescript/typescript6`, see [Installation](#installation)).
 - **Known Gaps:** If you find any `Json` fields that are not being typed correctly, please [open an issue](https://github.com/arthurfiorette/prisma-json-types-generator/issues).
 
 <br />

--- a/package.json
+++ b/package.json
@@ -50,15 +50,23 @@
     "@prisma/generator": "^7.8.0",
     "@types/node": "^26.1.0",
     "@types/semver": "^7.7.1",
+    "@typescript/typescript6": "^6.0.2",
     "husky": "^9.1.7",
     "prisma": "^7.8.0",
     "tsd": "^0.33.0",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
   },
   "peerDependencies": {
     "@prisma/client": "^7.8.0",
+    "@typescript/typescript6": "^6.0.2",
     "prisma": "^7.8.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.2 || ^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@typescript/typescript6": {
+      "optional": true
+    }
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
     devDependencies:
       '@arthurfiorette/biomejs-config':
         specifier: ^2.0.1
@@ -45,6 +42,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
+      '@typescript/typescript6':
+        specifier: ^6.0.2
+        version: 6.0.2
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -57,6 +57,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.23.0
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
 
 packages:
 
@@ -496,6 +499,10 @@ packages:
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1515,6 +1522,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/semver@7.7.1': {}
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   ajv@8.18.0:
     dependencies:

--- a/src/handler/model-payload.ts
+++ b/src/handler/model-payload.ts
@@ -1,18 +1,19 @@
-import ts from 'typescript';
+import type { TypeAliasDeclaration, TypeLiteralNode } from 'typescript';
 import type { PrismaEntity } from '../helpers/dmmf';
 import type { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import type { DeclarationWriter } from '../util/declaration-writer';
 import { PrismaJsonTypesGeneratorError } from '../util/error';
+import ts from '../util/ts';
 import { replaceObject } from './replace-object';
 
 /** Replacer responsible for the main <Model>Payload type. */
 export function handleModelPayload(
-  typeAlias: ts.TypeAliasDeclaration,
+  typeAlias: TypeAliasDeclaration,
   writer: DeclarationWriter,
   model: PrismaEntity,
   config: PrismaJsonTypesGeneratorConfig
 ) {
-  const type = typeAlias.type as ts.TypeLiteralNode;
+  const type = typeAlias.type as TypeLiteralNode;
 
   if (type.kind !== ts.SyntaxKind.TypeLiteral) {
     throw new PrismaJsonTypesGeneratorError('Provided model payload is not a type literal', {
@@ -35,7 +36,7 @@ export function handleModelPayload(
   // this is the OBJECT part
   const object = (
     model.type === 'model' ? scalarsField?.type?.typeArguments?.[0] : scalarsField?.type
-  ) as ts.TypeLiteralNode;
+  ) as TypeLiteralNode;
 
   if (!object) {
     throw new PrismaJsonTypesGeneratorError('Payload scalars could not be resolved', {

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -1,15 +1,16 @@
 import { Result } from 'try';
-import ts from 'typescript';
+import type { Identifier, ModuleBlock, ModuleDeclaration } from 'typescript';
 import type { PrismaEntity } from '../helpers/dmmf';
 import type { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import { PRISMA_NAMESPACE_NAME } from '../util/constants';
 import type { DeclarationWriter } from '../util/declaration-writer';
 import { PrismaJsonTypesGeneratorError } from '../util/error';
+import ts from '../util/ts';
 import { handleStatement } from './statement';
 
 /** Handles the prisma namespace module. */
 export function handlePrismaModule(
-  child: ts.ModuleDeclaration,
+  child: ModuleDeclaration,
   writer: DeclarationWriter,
   modelMap: Map<string, PrismaEntity>,
   knownNoOps: Set<string>,
@@ -18,7 +19,7 @@ export function handlePrismaModule(
 ) {
   const name = child
     .getChildren()
-    .find((n): n is ts.Identifier => n.kind === ts.SyntaxKind.Identifier);
+    .find((n): n is Identifier => n.kind === ts.SyntaxKind.Identifier);
 
   // Not a prisma namespace
   if (!name || name.text !== PRISMA_NAMESPACE_NAME) {
@@ -27,7 +28,7 @@ export function handlePrismaModule(
 
   const content = child
     .getChildren()
-    .find((n): n is ts.ModuleBlock => n.kind === ts.SyntaxKind.ModuleBlock);
+    .find((n): n is ModuleBlock => n.kind === ts.SyntaxKind.ModuleBlock);
 
   if (!content?.statements.length) {
     throw new PrismaJsonTypesGeneratorError('Prisma namespace content could not be found');

--- a/src/handler/replace-object.ts
+++ b/src/handler/replace-object.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import type { PropertySignature, TypeLiteralNode } from 'typescript';
 import type { PrismaEntity } from '../helpers/dmmf';
 import { findNewSignature } from '../helpers/find-signature';
 import { parseTypeSyntax } from '../helpers/type-parser';
@@ -6,10 +6,11 @@ import type { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import { createType } from '../util/create-signature';
 import type { DeclarationWriter } from '../util/declaration-writer';
 import { PrismaJsonTypesGeneratorError } from '../util/error';
+import ts from '../util/ts';
 
 /** Tries to replace every property of an object */
 export function replaceObject(
-  object: ts.TypeLiteralNode,
+  object: TypeLiteralNode,
   writer: DeclarationWriter,
   model: PrismaEntity,
   config: PrismaJsonTypesGeneratorConfig
@@ -36,7 +37,7 @@ export function replaceObject(
       }
 
       // the original `field: Type`
-      const signature = (member as ts.PropertySignature).type;
+      const signature = (member as PropertySignature).type;
 
       if (!signature) {
         throw new PrismaJsonTypesGeneratorError('Could not find signature type', {

--- a/src/handler/statement.ts
+++ b/src/handler/statement.ts
@@ -1,8 +1,9 @@
-import ts from 'typescript';
+import type { Statement, TypeAliasDeclaration, TypeLiteralNode } from 'typescript';
 import type { PrismaEntity } from '../helpers/dmmf';
 import { extractBaseNameFromRelationType } from '../helpers/regex';
 import type { PrismaJsonTypesGeneratorConfig } from '../util/config';
 import type { DeclarationWriter } from '../util/declaration-writer';
+import ts from '../util/ts';
 import { handleModelPayload } from './model-payload';
 import { replaceObject } from './replace-object';
 
@@ -11,7 +12,7 @@ import { replaceObject } from './replace-object';
  * where/create/update input/output
  */
 export function handleStatement(
-  statement: ts.Statement,
+  statement: Statement,
   writer: DeclarationWriter,
   modelMap: Map<string, PrismaEntity>,
   typeToNameMap: Map<string, string>,
@@ -22,7 +23,7 @@ export function handleStatement(
     return;
   }
 
-  const type = statement as ts.TypeAliasDeclaration;
+  const type = statement as TypeAliasDeclaration;
 
   // Filters any statement that isn't a export type declaration
   if (type.type.kind !== ts.SyntaxKind.TypeLiteral) {
@@ -44,7 +45,7 @@ export function handleStatement(
       if (typeName === `$${modelName}Payload`) {
         return handleModelPayload(type, writer, model, config);
       }
-      return replaceObject(type.type as ts.TypeLiteralNode, writer, model, config);
+      return replaceObject(type.type as TypeLiteralNode, writer, model, config);
     }
   } else {
     // If the type name isn't constant, match the model name using a regex, then do the lookup
@@ -52,7 +53,7 @@ export function handleStatement(
     if (baseName) {
       const model = modelMap.get(baseName);
       if (model) {
-        return replaceObject(type.type as ts.TypeLiteralNode, writer, model, config);
+        return replaceObject(type.type as TypeLiteralNode, writer, model, config);
       }
     }
   }

--- a/src/on-generate.ts
+++ b/src/on-generate.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import { join } from 'node:path';
 import type { GeneratorOptions } from '@prisma/generator';
-import ts from 'typescript';
+import type { ModuleDeclaration, Statement } from 'typescript';
 import { handlePrismaModule } from './handler/module';
 import { handleStatement } from './handler/statement';
 import { extractPrismaModels } from './helpers/dmmf';
@@ -9,6 +9,7 @@ import { type PrismaJsonTypesGeneratorConfig, parseConfig } from './util/config'
 import { DeclarationWriter, getNamespacePrelude } from './util/declaration-writer';
 import { findPrismaClientGenerators, type GeneratorWithOutput } from './util/prisma-generator';
 import { buildTypesFilePath } from './util/source-path';
+import ts from './util/ts';
 
 /** Runs the generator with the given options. */
 export async function onGenerate(options: GeneratorOptions) {
@@ -92,7 +93,7 @@ async function handleDeclarationFile(
       if (!multifile) {
         if (child.kind === ts.SyntaxKind.ModuleDeclaration) {
           handlePrismaModule(
-            child as ts.ModuleDeclaration,
+            child as ModuleDeclaration,
             writer,
             modelMap,
             knownNoOps,
@@ -102,14 +103,7 @@ async function handleDeclarationFile(
         }
       } else {
         if (ts.isStatement(child)) {
-          handleStatement(
-            child as ts.Statement,
-            writer,
-            modelMap,
-            typeToNameMap,
-            knownNoOps,
-            config
-          );
+          handleStatement(child as Statement, writer, modelMap, typeToNameMap, knownNoOps, config);
         }
       }
     } catch (error) {

--- a/src/util/ts.ts
+++ b/src/util/ts.ts
@@ -1,0 +1,49 @@
+import type TS from 'typescript';
+
+/** Checks that a module exposes the compiler API members this generator uses. */
+function hasCompilerApi(mod: unknown): mod is typeof TS {
+  return (
+    typeof mod === 'object' &&
+    mod !== null &&
+    typeof (mod as typeof TS).createSourceFile === 'function' &&
+    typeof (mod as typeof TS).isStatement === 'function' &&
+    typeof (mod as typeof TS).SyntaxKind === 'object'
+  );
+}
+
+/**
+ * Resolves the TypeScript compiler API used to parse the generated client declarations.
+ *
+ * TypeScript 6 exposes it from the `typescript` package itself. TypeScript 7 (the native
+ * compiler) no longer ships a JS API, so we fall back to `@typescript/typescript6`,
+ * Microsoft's compatibility package that re-exports the TypeScript 6 API.
+ */
+function loadCompilerApi(): typeof TS {
+  try {
+    const ts = require('typescript');
+
+    if (hasCompilerApi(ts)) {
+      return ts;
+    }
+  } catch {}
+
+  try {
+    const ts6 = require('@typescript/typescript6');
+
+    if (hasCompilerApi(ts6)) {
+      return ts6;
+    }
+  } catch {}
+
+  throw new Error(
+    `prisma-json-types-generator requires the TypeScript compiler API, but the installed 'typescript' package does not provide it.
+TypeScript 7 no longer ships the JS compiler API this generator uses. Install the official compatibility package:
+
+  npm install -D @typescript/typescript6
+`
+  );
+}
+
+// Resolved at module load so a missing compiler API fails `prisma generate` loudly
+// instead of being swallowed by onGenerate's catch-all error handler.
+export default loadCompilerApi();


### PR DESCRIPTION
TypeScript 7 is GA and is now `typescript@latest`, but it no longer ships the JS compiler API this generator uses to parse the generated client declarations. The failure mode depends on the version: `7.0.1-rc` had no root export, so `prisma generate` crashed with `ERR_PACKAGE_PATH_NOT_EXPORTED` (#692). `7.0.2` exports a version-only stub, so the resulting `TypeError` is swallowed by the catch-all in `onGenerate` and `prisma generate` exits 0 with Json fields silently reverting to `JsonValue` (#694).

Waiting this out is not really an option either. Per the [7.0 announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/), the replacement API is planned for TypeScript 7.1, which on the stated release cadence of every 3 to 4 months puts it at October 2026 at the earliest; it will also be "a new (and different) API", so adopting it would be a separate migration on its own timeline. Microsoft's recommended bridge for tools in the meantime is `@typescript/typescript6`, which re-exports the TypeScript 6 API.

This adds TypeScript 7 support without changing anything for TypeScript 6 users:

- all compiler API access goes through one loader (`src/util/ts.ts`) that uses the installed `typescript` package when it exposes the API and falls back to `@typescript/typescript6` when it does not
- `@typescript/typescript6` is an optional peer: TypeScript 6 users install nothing new, TypeScript 7 users add it as a dev dependency
- the loader resolves at module load, so a missing API fails `prisma generate` loudly with install instructions instead of silently skipping type replacement
- the `typescript` peer range becomes `^6.0.2 || ^7.0.0`; the current `^6.0.3` also rejects the alias workaround suggested in the announcement, which resolves as `typescript@6.0.2` and fails `npm install` with `ERESOLVE`
- CI gains a job that runs the full e2e suite against `typescript@7` to cover the fallback path

Verified locally: lint, build, unit tests and the full e2e suite pass on TypeScript 6. With `typescript@7` installed, lint, unit tests and the full e2e suite pass again through the fallback; the repo itself intentionally keeps building with TypeScript 6, which is what the devDependency pin is for. In a clean npm project with `typescript@7.0.2`: install resolves without `ERESOLVE`, generation fails with the actionable error when `@typescript/typescript6` is missing, and produces correctly typed Json fields once it is installed.

Fixes #694. Alternative to #692 (same diagnosis, credit to @davidjbng), restructured per the maintainer feedback there: no new dependency for existing users.

About the `package.json` changes... they look like spaghetti, but each entry is important.

- `typescript` peer `^6.0.2 || ^7.0.0`: the actual support statement. TS7 projects can't install without it.
- `@typescript/typescript6` as an optional peer: declaring it is what lets pnpm's strict `node_modules` resolve the fallback `require` at all; the `optional` flag is what keeps TS6 installs from warning about a package they don't need.
- `typescript` in devDependencies: this repo relies on `auto-install-peers`, so once the peer range includes `^7` the repo itself would start pulling TS7 and the build would break. Pinning `^6` keeps development on the API the code is written against.
- `@typescript/typescript6` in devDependencies: optional peers are never auto installed, and the new CI job needs it present to exercise the fallback.

Net effect: on TS6 nothing changes; no new packages are installed and the loader picks the existing `typescript` first, so behavior is identical to today. On TS7 the install resolves instead of failing with `ERESOLVE`, and generation either works (compat package present) or fails with a message saying exactly what to install.

Why `6.0.2` instead of the old `6.0.3` floor: [`@typescript/typescript6`](https://www.npmjs.com/package/@typescript/typescript6?activeTab=versions) is only published up to `6.0.2`; there is no `6.0.3` of it. The alias workaround in the 7.0 blog post installs that package under the `typescript` name, so npm sees `typescript@6.0.2` and the old `^6.0.3` peer rejects the install with `ERESOLVE`. Lowering the floor one patch makes the officially suggested setup work. Keeping `^6.0.3` is also fine if the alias path isn't a priority; no strong feelings there.


